### PR TITLE
Cure double interrupt on PIR

### DIFF
--- a/examples/RF12/roomNode/roomNode.ino
+++ b/examples/RF12/roomNode/roomNode.ino
@@ -101,7 +101,7 @@ struct {
             byte f = value;
             if (lastOn > 0)
                 ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                    if (millis() - lastOn < 1000 * PIR_HOLD_TIME)
+                    if (millis() - lastOn < (uint32_t)(1000 * PIR_HOLD_TIME))
                         f = 1;
                 }
             return f;


### PR DESCRIPTION
I think this comparison gets messed up. Without this change I get two interrupt packets for each PIR event.
