### PR TITLE
Added defined(__AVR_ATtin88__) in Sleepy::loseSomeTime().

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1168,7 +1168,7 @@ byte Sleepy::loseSomeTime (word msecs) {
         msleft -= halfms;
     }
     // adjust the milli ticks, since we will have missed several
-#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__)
+#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__) || defined (__AVR_ATtiny88__)
     extern volatile unsigned long millis_timer_millis;
     millis_timer_millis += msecs - msleft;
 #else


### PR DESCRIPTION
This allowed use of JeeLib on ATTiny88-PU MCU using TinyCore from https://github.com/SpenceKonde/ATTinyCore